### PR TITLE
EMPIREDB-285 : Escape sequence name properly when dropping sequence in Oracle and HSql

### DIFF
--- a/empire-db/src/main/java/org/apache/empire/db/hsql/HSqlDDLGenerator.java
+++ b/empire-db/src/main/java/org/apache/empire/db/hsql/HSqlDDLGenerator.java
@@ -92,7 +92,10 @@ public class HSqlDDLGenerator extends DBDDLGenerator<DBDatabaseDriverHSql>
                 if (c.getDataType() == DataType.AUTOINC && (c instanceof DBTableColumn))
                 {   // SEQUENCE column
                     DBTableColumn column = (DBTableColumn) c;
-                    script.addStmt("DROP SEQUENCE " + column.getSequenceName());
+                    StringBuilder sql = new StringBuilder("DROP SEQUENCE ");
+                    //Sequence name can contain special characters
+                    appendElementName(sql, column.getSequenceName());
+                    script.addStmt(sql.toString());
                 }
             }
         }

--- a/empire-db/src/main/java/org/apache/empire/db/oracle/OracleDDLGenerator.java
+++ b/empire-db/src/main/java/org/apache/empire/db/oracle/OracleDDLGenerator.java
@@ -128,7 +128,10 @@ public class OracleDDLGenerator extends DBDDLGenerator<DBDatabaseDriverOracle>
                 if (c.getDataType() == DataType.AUTOINC && (c instanceof DBTableColumn))
                 {   // SEQUENCE column
                     DBTableColumn column = (DBTableColumn) c;
-                    script.addStmt("DROP SEQUENCE " + column.getSequenceName());
+                    StringBuilder sql = new StringBuilder("DROP SEQUENCE ");
+                    //Sequence name can contain special characters
+                    appendElementName(sql, column.getSequenceName());
+                    script.addStmt(sql.toString());
                 }
             }
         }


### PR DESCRIPTION
This is the fix for https://issues.apache.org/jira/browse/EMPIREDB-285