### PR TITLE
Bugfix ObjectUtils isZero method for type decimal 

### DIFF
--- a/empire-db/src/main/java/org/apache/empire/commons/ObjectUtils.java
+++ b/empire-db/src/main/java/org/apache/empire/commons/ObjectUtils.java
@@ -150,7 +150,7 @@ public final class ObjectUtils
         if (value instanceof Float)
             return (((Float) value).compareTo(0.0f)==0);
         if (value instanceof Double)
-            return (((Float) value).compareTo(0.0f)==0);
+            return (((Double) value).compareTo(0.0d)==0);
         if (value instanceof Long)
             return (value.longValue()==0l);
         // default: check int value

--- a/empire-db/src/test/java/org/apache/empire/commons/ObjectUtilsTest.java
+++ b/empire-db/src/test/java/org/apache/empire/commons/ObjectUtilsTest.java
@@ -20,6 +20,7 @@ package org.apache.empire.commons;
 
 import static org.junit.Assert.*;
 
+import java.math.BigDecimal;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -51,6 +52,21 @@ public class ObjectUtilsTest
 		assertFalse(ObjectUtils.isEmpty(" "));
 		assertFalse(ObjectUtils.isEmpty(new Object()));
 	}
+
+	@Test
+    public void testIsZero()
+    {
+        assertTrue(ObjectUtils.isZero(BigDecimal.ZERO));
+        assertTrue(ObjectUtils.isZero(0f));
+        assertTrue(ObjectUtils.isZero(Float.valueOf("0")));
+        assertTrue(ObjectUtils.isZero(0d));
+        assertTrue(ObjectUtils.isZero(0l));
+        assertTrue(ObjectUtils.isZero(0));
+		assertTrue(ObjectUtils.isZero(null));
+		assertFalse(ObjectUtils.isZero(0.1d));
+        assertFalse(ObjectUtils.isZero(444l));
+        assertFalse(ObjectUtils.isZero(-0.01f));
+    }
 
 	/**
 	 * Test method for

--- a/empire-db/src/test/java/org/apache/empire/commons/ObjectUtilsTest.java
+++ b/empire-db/src/test/java/org/apache/empire/commons/ObjectUtilsTest.java
@@ -54,19 +54,19 @@ public class ObjectUtilsTest
 	}
 
 	@Test
-    public void testIsZero()
-    {
-        assertTrue(ObjectUtils.isZero(BigDecimal.ZERO));
-        assertTrue(ObjectUtils.isZero(0f));
-        assertTrue(ObjectUtils.isZero(Float.valueOf("0")));
-        assertTrue(ObjectUtils.isZero(0d));
-        assertTrue(ObjectUtils.isZero(0l));
-        assertTrue(ObjectUtils.isZero(0));
+	public void testIsZero()
+	{
+		assertTrue(ObjectUtils.isZero(BigDecimal.ZERO));
+		assertTrue(ObjectUtils.isZero(0f));
+		assertTrue(ObjectUtils.isZero(Float.valueOf("0")));
+		assertTrue(ObjectUtils.isZero(0d));
+		assertTrue(ObjectUtils.isZero(0l));
+		assertTrue(ObjectUtils.isZero(0));
 		assertTrue(ObjectUtils.isZero(null));
 		assertFalse(ObjectUtils.isZero(0.1d));
-        assertFalse(ObjectUtils.isZero(444l));
-        assertFalse(ObjectUtils.isZero(-0.01f));
-    }
+		assertFalse(ObjectUtils.isZero(444l));
+		assertFalse(ObjectUtils.isZero(-0.01f));
+	}
 
 	/**
 	 * Test method for


### PR DESCRIPTION
In the method isZero in ObjectUtils is an likely copy paste bug.
The cast and check for instanceof double is Float.
This leads to an exception if isZero is called for decimal values.

I fixed this error and added an unit test for the method isZero.