### PR TITLE
Fix StringUtils.lastIndexOfAny start index

### DIFF
--- a/empire-db/src/main/java/org/apache/empire/commons/StringUtils.java
+++ b/empire-db/src/main/java/org/apache/empire/commons/StringUtils.java
@@ -339,7 +339,7 @@ public class StringUtils
         if (value==null || chars.length==0)
             return -1;
         // search
-        for (int i=value.length(); i>=0; i--) {
+        for (int i = value.length() - 1; i >= 0; i--) {
             char c = value.charAt(i);
             for (int j=0; j<chars.length; j++)
                 if (c==chars[j])

--- a/empire-db/src/test/java/org/apache/empire/commons/StringUtilsTest.java
+++ b/empire-db/src/test/java/org/apache/empire/commons/StringUtilsTest.java
@@ -318,5 +318,22 @@ public class StringUtilsTest
         assertEquals("ABC", StringUtils.toCamelCase(" _a_ _b_ _c_ ", true));
         assertEquals("aBC", StringUtils.toCamelCase(" _a_ _b_ _c_ ", false));
     }
+    
+    @Test
+    public void lastIndexOfAnyShouldReturnLastMatchingCharacterIndex() 
+    {
+        assertEquals(3, StringUtils.lastIndexOfAny("abca", 'a'));
+        assertEquals(2, StringUtils.lastIndexOfAny("abc", 'c'));
+        assertEquals(1, StringUtils.lastIndexOfAny("abc", 'b', 'x'));
+    }
+
+    @Test
+    public void lastIndexOfAnyShouldReturnMinusOneWhenNoCharacterMatches() 
+    {
+        assertEquals(-1, StringUtils.lastIndexOfAny("abc", 'x'));
+        assertEquals(-1, StringUtils.lastIndexOfAny("", 'x'));
+        assertEquals(-1, StringUtils.lastIndexOfAny(null, 'x'));
+    }
+
 
 }


### PR DESCRIPTION
### Summary

Fixes an off-by-one error in `StringUtils.lastIndexOfAny`.

The method currently starts reverse iteration from `value.length()`, but the last valid character index is `value.length() - 1`. For non-empty strings, this can cause `StringIndexOutOfBoundsException` when `value.charAt(i)` is called.

### Changes

- Start reverse iteration from `value.length() - 1`
- Add unit tests for:
  - matching the last character
  - matching an earlier character
  - no match
  - empty string
  - null input

### Jira

I have requested access to Apache Jira, but the account approval is still pending. I am raising this PR first because the fix is small and straightforward.

Once my Jira account is approved, I can create/link the corresponding EMPIREDB Jira issue if required.

### Verification

```bash
mvn -pl empire-db -Dtest=StringUtilsTest test
mvn -pl empire-db test